### PR TITLE
Delete useless php version at composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^7.3",
+        "php": "^7.1",
         "guzzlehttp/guzzle": "^6.4|^7.0",
         "illuminate/support": "5.8.*|6.*|7.*|8.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^7.3",
         "guzzlehttp/guzzle": "^6.4|^7.0",
         "illuminate/support": "5.8.*|6.*|7.*|8.*"
     },


### PR DESCRIPTION
Its not necessary to add 7.3 version, because ^7.1 will match all versions above that number.

See more [here](https://jubianchi.github.io/semver-check/#/%5E7.1/%5E7.3).